### PR TITLE
Simple `log_wrap`

### DIFF
--- a/SpdLog/SpdLog.cpp
+++ b/SpdLog/SpdLog.cpp
@@ -1,10 +1,9 @@
 #include <conio.h>
 #include <atlstr.h>
+#include <ShlObj.h>
 
 #include "log_manager.h"
 #include "service_worker.h"
-
-#include <ShlObj.h>
 
 std::string get_program_data_folder()
 {
@@ -31,12 +30,12 @@ int main()
 
     const auto base_path = std::filesystem::path{ program_data } / "SpdLog";
 
-    log_manager::instance().initialize(base_path);
+    if(!log_manager::instance().initialize(base_path))
+    {
+        return 1;
+    }
 
     std::clog << "log_manager initialized" << std::endl;
-
-    spdlog::info("Welcome to spdlog!");
-
 
     service_worker worker_foo("Foo");
     service_worker worker_bar("Bar");


### PR DESCRIPTION
Different approach to #1 

1. instead of lazy initialization have just a simple wrapper that provides 'category' and uses one of pre-initialized `spdlog` loggers
2. do not define `SPDLOG_NO_EXCEPTIONS` -- `spdlog::logger` does not rethrow `std::exception`
3. no mutex needed