### PR TITLE
`log_manager` prototype

### DIFF
--- a/SpdLog/SpdLog.cpp
+++ b/SpdLog/SpdLog.cpp
@@ -1,10 +1,9 @@
 #include <conio.h>
 #include <atlstr.h>
+#include <ShlObj.h>
 
 #include "log_manager.h"
 #include "service_worker.h"
-
-#include <ShlObj.h>
 
 std::string get_program_data_folder()
 {
@@ -31,17 +30,17 @@ int main()
 
     const auto base_path = std::filesystem::path{ program_data } / "SpdLog";
 
-    log_manager::instance().initialize(base_path);
+    if(!log_manager::instance().initialize(base_path))
+    {
+        return 1;
+    }
 
     std::clog << "log_manager initialized" << std::endl;
-
-    spdlog::info("Welcome to spdlog!");
-
 
     service_worker worker_foo("Foo");
     service_worker worker_bar("Bar");
 
-    std::cout << "Press any key to continue. . .\n";
+    std::cout << "Press any key to continue. . ." << std::endl;
     _getch();
 
     worker_foo.stop();

--- a/SpdLog/SpdLog.cpp
+++ b/SpdLog/SpdLog.cpp
@@ -5,32 +5,23 @@
 #include "log_manager.h"
 #include "service_worker.h"
 
-std::string get_program_data_folder()
+std::string expand_environment_strings(const std::string& src)
 {
-    PWSTR ppszPath = nullptr;
-    if (SHGetKnownFolderPath(FOLDERID_ProgramData, KF_FLAG_DEFAULT, nullptr, &ppszPath) == S_OK)
-    {
-        std::string program_data(CW2A(ppszPath, CP_UTF8));
-        CoTaskMemFree(ppszPath);
-        return program_data;
-    }
-
-    return {};
+    _TCHAR dest_buffer[MAX_PATH];
+    ExpandEnvironmentStrings(CA2W(src.c_str(), CP_UTF8).m_psz, dest_buffer, ARRAYSIZE(dest_buffer));
+    return {CW2A(dest_buffer, CP_UTF8).m_szBuffer};
 }
 
 int main()
 {
     std::clog << "main function" << std::endl;
-    const auto program_data = get_program_data_folder();
-    if (program_data.empty())
-    {
-        std::cerr << "Fatal error: Unable to resolve ProgramData folder!" << std::endl;
-        return 1;
-    }
 
-    const auto base_path = std::filesystem::path{ program_data } / "SpdLog";
+    std::string base_log_path(R"(%ALLUSERSPROFILE%\SpdLog)");
+    base_log_path = expand_environment_strings(base_log_path);
 
-    if(!log_manager::instance().initialize(base_path))
+    std::clog << "expanded log directory path: " << base_log_path << std::endl;
+
+    if(!log_manager::instance().initialize(std::filesystem::path{ base_log_path }))
     {
         return 1;
     }

--- a/SpdLog/SpdLog.vcxproj
+++ b/SpdLog/SpdLog.vcxproj
@@ -58,6 +58,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -78,6 +79,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>

--- a/SpdLog/log_manager.h
+++ b/SpdLog/log_manager.h
@@ -1,0 +1,250 @@
+#pragma once
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#define SPDLOG_LEVEL_NAMES \
+    { spdlog::string_view_t("TRACE", 5) \
+    , spdlog::string_view_t("DEBUG", 5) \
+    , spdlog::string_view_t("INFO", 4)  \
+    , spdlog::string_view_t("WARN", 4)  \
+    , spdlog::string_view_t("ERROR", 5) \
+    , spdlog::string_view_t("FATAL", 5) \
+    , spdlog::string_view_t("OFF", 3) }
+
+#pragma warning(push)
+#pragma warning ( disable: 4307 ) // spdlog warning C4307: '*': integral constant overflow
+#include <spdlog/logger.h>
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#pragma warning(pop)
+
+#define LOG_DEBUG(logger, ...) { \
+        if (logger.should_log(spdlog::level::debug)) {\
+           logger.log(spdlog::level::debug, __VA_ARGS__); }}
+
+#define LOG_TRACE(logger, ...) { \
+        if (logger.should_log(spdlog::level::trace)) {\
+           logger.log(spdlog::level::trace, __VA_ARGS__); }}
+
+
+class log_wrap;
+
+class log_manager
+{
+    static const std::string root_logger_name;
+    static const std::string messaging_logger_name;
+
+    static const std::string log_pattern;
+
+    log_manager();
+
+    static std::shared_ptr<spdlog::logger> get_root_category();
+
+    static std::shared_ptr<spdlog::logger> get_messaging_category();
+
+public:
+    friend log_wrap;
+
+    static log_wrap create_logger(std::string);
+    static log_wrap create_messaging_logger(std::string);
+
+    bool initialize(const std::filesystem::path& base_path) const
+    {
+        static constexpr std::size_t max_size = 1024;
+        static constexpr std::size_t max_files = 3;
+        static spdlog::level::level_enum global_level = spdlog::level::info;
+
+        spdlog::file_event_handlers handlers;
+        handlers.after_open = [](const spdlog::filename_t&, std::FILE *file_stream) { (void)fputs("*** SpdLog Service v2023.4.0.1070 ***\n", file_stream); };
+        try
+        {
+            spdlog::drop_all(); // remove implicit default logger
+
+            const auto default_log_path = base_path / "default.log";
+            const auto default_logger = get_root_category();
+            default_logger->sinks()
+                .emplace_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(default_log_path.generic_string(), max_size, max_files, false, handlers));
+
+            spdlog::set_default_logger(default_logger);
+            spdlog::set_pattern(log_pattern); // must be set after set_default_logger
+            spdlog::set_level(global_level);
+
+            const auto messaging_log_path = base_path / "messaging.log";
+            const auto messaging_logger = get_messaging_category();
+            messaging_logger->sinks()
+                .emplace_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(messaging_log_path.generic_string(), max_size, max_files, false, handlers));
+            spdlog::initialize_logger(messaging_logger);
+
+            using namespace std::chrono_literals;
+            spdlog::flush_every(5s);
+            return true;
+        }
+        catch (const spdlog::spdlog_ex& e)
+        {
+            std::cerr << "Unable to initialize logging: " << e.what() << std::endl;
+        }
+
+        return false;
+    }
+
+    static void shutdown();
+
+    static log_manager &instance();
+
+};
+
+class log_wrap
+{
+    std::string name_;
+    std::shared_ptr<spdlog::logger> log_;
+
+    explicit log_wrap(std::string name, std::shared_ptr<spdlog::logger> log)
+        : name_(std::move(name)), log_(std::move(log))
+    {
+        std::clog << "ctor " << log_->name() << "." << name_ << std::endl;
+    }
+
+public:
+    friend log_manager;
+
+    log_wrap(const log_wrap&) = delete;
+    log_wrap& operator=(const log_wrap&) = delete;
+
+    log_wrap(log_wrap&& rhs) noexcept
+        : name_(std::move(rhs.name_)), log_(std::move(rhs.log_))
+    {
+        std::clog << "mv ctor " << log_->name() << "." << name_ << std::endl;
+    }
+
+    log_wrap& operator=(log_wrap&& rhs) noexcept
+    {
+        name_ = std::move(rhs.name_);
+        log_ = std::move(rhs.log_);
+        std::clog << "mv assigned " << log_->name() << "." << name_ << std::endl;
+        return *this;
+    }
+
+    template<typename... Args>
+    void trace(spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        log(spdlog::level::trace, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void debug(spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        log(spdlog::level::debug, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void info(spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        log(spdlog::level::info, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void warn(spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        log(spdlog::level::warn, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void error(spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        log(spdlog::level::err, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void fatal(spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        log(spdlog::level::critical, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void log(spdlog::level::level_enum lvl, spdlog::format_string_t<Args...> fmt, Args &&...args) const
+    {
+        
+        std::clog << std::string(">  log ").append(spdlog::level::to_string_view(lvl).data()).append("\n");
+
+        log_->log(spdlog::source_loc{ "", 1, name_.c_str() }, lvl, fmt, std::forward<Args>(args)...);
+    }
+
+    bool is_trace_enabled() const
+    {
+        return should_log(spdlog::level::trace);
+    }
+
+    bool is_debug_enabled() const
+    {
+        return should_log(spdlog::level::debug);
+    }
+
+    bool is_info_enabled() const
+    {
+        return should_log(spdlog::level::info);
+    }
+
+    bool is_warn_enabled() const
+    {
+        return should_log(spdlog::level::warn);
+    }
+
+    bool is_error_enabled() const
+    {
+        return should_log(spdlog::level::err);
+    }
+
+    bool is_fatal_enabled() const
+    {
+        return should_log(spdlog::level::critical);
+    }
+
+    bool should_log(const spdlog::level::level_enum msg_level) const
+    {
+        return log_->should_log(msg_level);
+    }
+};
+
+const std::string log_manager::root_logger_name("spdlog");
+const std::string log_manager::messaging_logger_name("messaging");
+
+// hack %! use source_loc.funcname as category name
+const std::string log_manager::log_pattern("%Y-%m-%d %H:%M:%S,%e [%t] %l %! - %v");
+
+inline log_manager::log_manager() = default;
+
+inline log_wrap log_manager::create_logger(std::string name)
+{
+    return log_wrap(std::move(name), get_root_category());
+}
+
+inline log_wrap log_manager::create_messaging_logger(std::string name)
+{
+    return log_wrap(std::move(name), get_messaging_category());
+}
+
+inline void log_manager::shutdown()
+{
+    get_root_category().reset();
+    get_messaging_category().reset();
+    spdlog::shutdown();
+}
+
+inline log_manager &log_manager::instance()
+{
+    static log_manager static_instance;
+    return static_instance;
+}
+
+inline std::shared_ptr<spdlog::logger> log_manager::get_root_category()
+{
+    static auto static_instance = std::make_shared<spdlog::logger>(root_logger_name);
+    return static_instance;
+}
+
+inline std::shared_ptr<spdlog::logger> log_manager::get_messaging_category()
+{
+    static auto static_instance = std::make_shared<spdlog::logger>(messaging_logger_name);
+    return static_instance;
+}

--- a/SpdLog/log_manager.h
+++ b/SpdLog/log_manager.h
@@ -12,11 +12,14 @@
     , spdlog::string_view_t("FATAL", 5) \
     , spdlog::string_view_t("OFF", 3) }
 
+#define SPDLOG_WCHAR_TO_UTF8_SUPPORT
+
 #pragma warning(push)
 #pragma warning ( disable: 4307 ) // spdlog warning C4307: '*': integral constant overflow
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/fmt/ostr.h> // provides std::ostream support including formatting of user-defined types that have overloaded operator<<:
 #pragma warning(pop)
 
 #define LOG_DEBUG(logger, ...) { \
@@ -96,6 +99,8 @@ public:
 
 class log_wrap
 {
+    static constexpr const char* empty_str = "";
+
     std::string name_;
     std::shared_ptr<spdlog::logger> log_;
 
@@ -128,46 +133,87 @@ public:
     template<typename... Args>
     void trace(spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        log(spdlog::level::trace, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::level::trace, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void trace(spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::level::trace, fmt, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void debug(spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        log(spdlog::level::debug, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::level::debug, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void debug(spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::level::debug, fmt, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void info(spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        log(spdlog::level::info, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::level::info, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void info(spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::level::info, fmt, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void warn(spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        log(spdlog::level::warn, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::level::warn, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void warn(spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::level::warn, fmt, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void error(spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        log(spdlog::level::err, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::level::err, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void error(spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::level::err, fmt, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void fatal(spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        log(spdlog::level::critical, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::level::critical, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void fatal(spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::level::critical, fmt, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void log(spdlog::level::level_enum lvl, spdlog::format_string_t<Args...> fmt, Args &&...args) const
     {
-        
         std::clog << std::string(">  log ").append(spdlog::level::to_string_view(lvl).data()).append("\n");
 
-        log_->log(spdlog::source_loc{ "", 1, name_.c_str() }, lvl, fmt, std::forward<Args>(args)...);
+        log_->log(spdlog::source_loc{ empty_str, 1, name_.c_str() }, lvl, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void log(spdlog::level::level_enum lvl, spdlog::wformat_string_t<Args...> fmt, Args &&...args)
+    {
+        log_->log(spdlog::source_loc{ empty_str, 1, name_.c_str() }, lvl, fmt, std::forward<Args>(args)...);
     }
 
     bool is_trace_enabled() const

--- a/SpdLog/service_worker.h
+++ b/SpdLog/service_worker.h
@@ -1,0 +1,72 @@
+﻿#pragma once
+#include <atomic>
+#include <thread>
+
+#include "log_manager.h"
+
+// log4cxx
+// static LoggerPtr _log(Logger::getLogger("agent_messaging"));
+// static LoggerPtr _log_msg(Logger::getLogger("messaging.agent_messaging"));
+
+static log_wrap _log = log_manager::create_logger("agent_messaging");
+static log_wrap _log_msg = log_manager::create_messaging_logger("agent_messaging");
+
+class service_worker
+{
+    std::string name_;
+    std::atomic_bool done_{};
+    std::thread worker_{}; // std::jthread is C++20
+
+    const log_wrap member_log_; //can be const it's just a wrapper
+
+public:
+
+    explicit service_worker(std::string name)
+        : name_(std::move(name)),
+          member_log_(log_manager::create_logger(name_))
+    {
+        this->worker_ = std::thread{ &service_worker::run, this };
+    }
+
+    service_worker(const service_worker&) = delete;
+    service_worker& operator=(const service_worker&) = delete;
+
+    void stop()
+    {
+        this->done_.store(true);
+    }
+
+    void join()
+    {
+        if (this->worker_.joinable())
+            this->worker_.join();
+    }
+
+private:
+
+    void run()
+    {
+        member_log_.info("instance logger", name_);
+        LOG_TRACE(member_log_, "instance trace")
+
+        _log.trace("{} static logger", name_);
+        _log.debug("{} static logger", name_);
+        _log.info("{} static logger", name_);
+        _log.warn("{} static logger", name_);
+        _log.error("{} static logger", name_);
+        _log.fatal("{} static logger", name_);
+
+        using namespace std::chrono_literals;
+        while (!this->done_.load())
+        {
+            // this produces:
+
+            // 2023-09-06 10:08:38,655 [3212] DEBUG agent_messaging - Bar is logging...
+            // 2023-09-06 10:08:38,657 [13516] DEBUG agent_messaging - Foo is logging...
+
+            // in c:\ProgramData\SpdLog\messaging.log like log4cxx nice...
+            LOG_DEBUG(_log_msg, "{} is logging...", name_)
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+};

--- a/SpdLog/service_worker.h
+++ b/SpdLog/service_worker.h
@@ -25,6 +25,7 @@ public:
         : name_(std::move(name)),
           member_log_(log_manager::create_logger(name_))
     {
+        _log.debug(R"(creating new service_worker({{"{}"}}))", name);
         this->worker_ = std::thread{ &service_worker::run, this };
     }
 
@@ -46,8 +47,14 @@ private:
 
     void run()
     {
-        member_log_.info("instance logger", name_);
         LOG_TRACE(member_log_, "instance trace")
+
+        // wformat_string_t
+        const std::wstring wstr(L"8Go de RAM est la quantité que nous recommandons pour une utilisation occasionnelle de votre ordinateur.");
+        _log.info(L"🛈 {} 🛈", wstr);
+        _log.info(L"Mémoire {}Go", 8);
+        _log.warn(L"Speicherkapazität {}kB", 512);
+        _log.debug(L"Aktivitätsträger {}", std::this_thread::get_id());
 
         _log.trace("{} static logger", name_);
         _log.debug("{} static logger", name_);


### PR DESCRIPTION
1. simple wrapper that has smart pointer to one of pre-initialized spdlog loggers
2. do not define SPDLOG_NO_EXCEPTIONS -- `spdlog::logger` does not rethrow `std::exception`
3. no mutex needed